### PR TITLE
Update Autostart.php

### DIFF
--- a/www/controllers/Motion/Autostart.php
+++ b/www/controllers/Motion/Autostart.php
@@ -245,14 +245,32 @@ class Autostart
                  *  If actual time is between autostart time slot, then start motion
                  */
                 $time = time();
-                $autostartTodayEndTmp;
+            	$autostartTodayEndTmp = time();
 
-                if (strtotime($autostartTodayStart) > (strtotime($autostartTodayEnd))) {
-                    $autostartTodayEndTmp = strtotime($autostartTodayEnd . " + 24 hours");
-                } else {
-                    $autostartTodayEndTmp = strtotime($autostartTodayEnd);
-                }
-                if ($time >= strtotime($autostartTodayStart) && $time < $autostartTodayEndTmp) {
+            	if (strtotime($autostartTodayStart) > strtotime($autostartTodayEnd)) {
+                	$autostartTodayEndTmp = strtotime($autostartTodayEnd . ' + 1 day');
+            	} else {
+                	$autostartTodayEndTmp = strtotime($autostartTodayEnd);
+            	}
+
+            	$previousDay = date('l', strtotime('yesterday'));
+            	$autostartYesterdayStart = $timeSlots[$previousDay . '_start'];
+            	$autostartYesterdayEnd = $timeSlots[$previousDay . '_end'];
+
+            	if ($autostartYesterdayEnd == '00:00') {
+                	$autostartYesterdayEnd = '23:59:59';
+            	}
+
+            	if (strtotime($autostartYesterdayStart) > strtotime($autostartYesterdayEnd)) {
+                	$autostartYesterdayEndTmp = strtotime($autostartYesterdayEnd . ' + 1 day');
+            	} else {
+                	$autostartYesterdayEndTmp = strtotime($autostartYesterdayEnd);
+            	}
+
+            	$yesterdayEndTime = strtotime('yesterday') + $autostartYesterdayEndTmp;
+
+                if (($time >= strtotime($autostartTodayStart) && $time < $autostartTodayEndTmp) ||
+		        ($time >= strtotime('yesterday') && $time < $yesterdayEndTime))	{
                     /**
                      *  Start motion only if not already running
                      */

--- a/www/controllers/Motion/Autostart.php
+++ b/www/controllers/Motion/Autostart.php
@@ -245,32 +245,32 @@ class Autostart
                  *  If actual time is between autostart time slot, then start motion
                  */
                 $time = time();
-            	$autostartTodayEndTmp = time();
+                $autostartTodayEndTmp = time();
 
-            	if (strtotime($autostartTodayStart) > strtotime($autostartTodayEnd)) {
-                	$autostartTodayEndTmp = strtotime($autostartTodayEnd . ' + 1 day');
-            	} else {
-                	$autostartTodayEndTmp = strtotime($autostartTodayEnd);
-            	}
+                if (strtotime($autostartTodayStart) > strtotime($autostartTodayEnd)) {
+                    $autostartTodayEndTmp = strtotime($autostartTodayEnd . ' + 1 day');
+                } else {
+                    $autostartTodayEndTmp = strtotime($autostartTodayEnd);
+                }
 
-            	$previousDay = date('l', strtotime('yesterday'));
-            	$autostartYesterdayStart = $timeSlots[$previousDay . '_start'];
-            	$autostartYesterdayEnd = $timeSlots[$previousDay . '_end'];
+                $previousDay = date('l', strtotime('yesterday'));
+                $autostartYesterdayStart = $timeSlots[$previousDay . '_start'];
+                $autostartYesterdayEnd = $timeSlots[$previousDay . '_end'];
 
-            	if ($autostartYesterdayEnd == '00:00') {
-                	$autostartYesterdayEnd = '23:59:59';
-            	}
+                if ($autostartYesterdayEnd == '00:00') {
+                    $autostartYesterdayEnd = '23:59:59';
+                }
 
-            	if (strtotime($autostartYesterdayStart) > strtotime($autostartYesterdayEnd)) {
-                	$autostartYesterdayEndTmp = strtotime($autostartYesterdayEnd . ' + 1 day');
-            	} else {
-                	$autostartYesterdayEndTmp = strtotime($autostartYesterdayEnd);
-            	}
+                if (strtotime($autostartYesterdayStart) > strtotime($autostartYesterdayEnd)) {
+                    $autostartYesterdayEndTmp = strtotime($autostartYesterdayEnd . ' + 1 day');
+                } else {
+                    $autostartYesterdayEndTmp = strtotime($autostartYesterdayEnd);
+                }
 
-            	$yesterdayEndTime = strtotime('yesterday') + $autostartYesterdayEndTmp;
+                $yesterdayEndTime = strtotime('yesterday') + $autostartYesterdayEndTmp;
 
                 if (($time >= strtotime($autostartTodayStart) && $time < $autostartTodayEndTmp) ||
-		        ($time >= strtotime('yesterday') && $time < $yesterdayEndTime))	{
+                ($time >= strtotime('yesterday') && $time < $yesterdayEndTime)) {
                     /**
                      *  Start motion only if not already running
                      */


### PR DESCRIPTION
Fixed a semantic error. The timestamp was taken from the current date, so for example, after a start at 18:00 o'clock, at the next day after 00:00 , the start time would not match anymore because it would be the next day 18:00 o'clock and not the timestamp from yesterday. Also the time tmp variable is now initialized as time.